### PR TITLE
make EOL=LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
fix line end encoding for other pojects when vendoring